### PR TITLE
bug-143

### DIFF
--- a/macros/src/main/scala/com/softwaremill/macwire/internals/TypeCheckUtil.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/internals/TypeCheckUtil.scala
@@ -43,7 +43,6 @@ private[macwire] class TypeCheckUtil[C <: blackbox.Context](val c: C, log: Logge
   def checkCandidate(target: Type, tpt: Type): Boolean = {
     val typesToCheck = tpt :: (tpt match {
       case NullaryMethodType(resultType) => List(resultType)
-      case MethodType(_, resultType) => List(resultType)
       case _ => Nil
     })
 

--- a/tests/src/test/resources/test-cases/nullaryMethodUsedAsCandidate.failure
+++ b/tests/src/test/resources/test-cases/nullaryMethodUsedAsCandidate.failure
@@ -1,0 +1,13 @@
+class A()
+class B(val a: A)
+
+object Module {
+  def foo(): A = new A()
+}
+
+object Test {
+  import Module._
+
+  val a: A = new A()
+  val b: B = wire[B]
+}

--- a/tests/src/test/resources/test-cases/parametrizedMethodNotUsedAsCandidate.success
+++ b/tests/src/test/resources/test-cases/parametrizedMethodNotUsedAsCandidate.success
@@ -1,0 +1,16 @@
+class A()
+class B(val a: A)
+class C()
+
+object Module {
+  def foo(c: C): A = new A()
+}
+
+object Test {
+  import Module._
+
+  val a: A = new A()
+  val b: B = wire[B]
+}
+
+require(Test.b.a eq Test.a)

--- a/tests/src/test/scala/com/softwaremill/macwire/CompileTests.scala
+++ b/tests/src/test/scala/com/softwaremill/macwire/CompileTests.scala
@@ -18,8 +18,8 @@ class CompileTests extends CompileTestsSupport {
       "phantomConstructor" -> List("Cannot find a public constructor nor a companion object for [Target]"),
       "companionObjectHasNoMethods" -> List("Companion object for",  "Target] has no apply methods constructing target type."),
       "companionObjectHasFakeApplyMethods" -> List("Companion object for",  "Target] has no apply methods constructing target type."),
-      "toManyInjectAnnotations" -> List("Ambiguous constructors annotated with @javax.inject.Inject for type [Target]")
-
+      "toManyInjectAnnotations" -> List("Ambiguous constructors annotated with @javax.inject.Inject for type [Target]"),
+      "nullaryMethodUsedAsCandidate" -> List("Found multiple values of type [A]: [List(foo, a)]")
     ),
     expectedWarnings = List(
       "forwardReferenceInBlock" -> List("Found [a] for parameter [a], but a forward reference [forwardA] was also eligible")


### PR DESCRIPTION
Fixes softwaremill/macwire#143

The issue is actually not related to tags. I eliminated tags from original bug report and the issue remains.

The issue comes from the fact that methods (with or without parameters) are treated as additional candidates for wiring.

I fixed the issue by limiting this feature only to methods without parameters.