### PR TITLE
add result type to implicit

### DIFF
--- a/tests/src/test/resources/test-cases/implicitDepsWiredWithImplementedImplicitVals.success
+++ b/tests/src/test/resources/test-cases/implicitDepsWiredWithImplementedImplicitVals.success
@@ -5,7 +5,7 @@ trait Abstract {
 }
 
 object Test extends Abstract {
-  override implicit val dependency = new Dependency
+  override implicit val dependency: Dependency = new Dependency
   val service = wire[Service]
 }
 


### PR DESCRIPTION
this came up at scala/community-build#1623; the relevant upcoming Scala 2.13.11 change is scala/scala#10083