### PR TITLE
Add macrosPekko and macrosPekkoTests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,9 @@ lazy val root = project
       testUtil,
       utilTests,
       macrosAkka,
+      macrosPekko,
       macrosAkkaTests,
+      macrosPekkoTests,
       macrosAutoCats,
       macrosAutoCatsTests
     ).flatMap(_.projectRefs): _*

--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ val tagging = "com.softwaremill.common" %% "tagging" % "2.3.1"
 val scalatest = "org.scalatest" %% "scalatest" % "3.2.9"
 val javassist = "org.javassist" % "javassist" % "3.29.2-GA"
 val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.6.20"
+val pekkoActor = "org.apache.pekko" %% "pekko-actor" % "1.0.1"
 val javaxInject = "javax.inject" % "javax.inject" % "1"
 val cats = "org.typelevel" %% "cats-core" % "2.10.0"
 val catsEffect = "org.typelevel" %% "cats-effect" % "3.5.1"
@@ -160,6 +161,14 @@ lazy val macrosAkka = projectMatrix
   .jvmPlatform(scalaVersions = scala2)
   .jsPlatform(scalaVersions = scala2)
 
+lazy val macrosPekko = projectMatrix
+  .in(file("macrosPekko"))
+  .settings(commonSettings)
+  .settings(libraryDependencies ++= Seq(pekkoActor % "provided"))
+  .dependsOn(macros)
+  .jvmPlatform(scalaVersions = scala2)
+  .jsPlatform(scalaVersions = scala2)
+
 lazy val macrosAkkaTests = projectMatrix
   .in(file("macrosAkkaTests"))
   .settings(
@@ -171,6 +180,19 @@ lazy val macrosAkkaTests = projectMatrix
   .settings(testSettings)
   .settings(libraryDependencies ++= Seq(scalatest, tagging, akkaActor))
   .dependsOn(macrosAkka, testUtil)
+  .jvmPlatform(scalaVersions = scala2)
+
+lazy val macrosPekkoTests = projectMatrix
+  .in(file("macrosPekkoTests"))
+  .settings(
+    // Needed to avoid cryptic EOFException crashes in forked tests in Travis
+    // example failure: https://travis-ci.org/adamw/macwire/builds/191382122
+    // see: https://github.com/travis-ci/travis-ci/issues/3775
+    javaOptions += "-Xmx1G"
+  )
+  .settings(testSettings)
+  .settings(libraryDependencies ++= Seq(scalatest, tagging, pekkoActor))
+  .dependsOn(macrosPekko, testUtil)
   .jvmPlatform(scalaVersions = scala2)
 
 lazy val macrosAutoCats = projectMatrix

--- a/macrosPekko/src/main/scala/com/softwaremill/macwire/pekkosupport/MacwirePekkoMacros.scala
+++ b/macrosPekko/src/main/scala/com/softwaremill/macwire/pekkosupport/MacwirePekkoMacros.scala
@@ -1,0 +1,32 @@
+package com.softwaremill.macwire.pekkosupport
+
+import org.apache.pekko.actor.{ActorRef, Props}
+import com.softwaremill.macwire.internals.Logger
+
+import scala.reflect.macros.blackbox
+
+object MacwirePekkoMacros {
+  private val log = new Logger()
+
+  def wireProps_Impl[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[Props] =
+    new internals.Crimper[c.type, T](c, log).wireProps
+  def wireAnonymousActor_Impl[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[ActorRef] =
+    new internals.Crimper[c.type, T](c, log).wireAnonymousActor
+  def wireActor_Impl[T: c.WeakTypeTag](c: blackbox.Context)(name: c.Expr[String]): c.Expr[ActorRef] =
+    new internals.Crimper[c.type, T](c, log).wireActor(name)
+
+  def wirePropsWithProducer_Impl[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[Props] =
+    new internals.Crimper[c.type, T](c, log).wirePropsWithProducer
+  def wireAnonymousActorWithProducer_Impl[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[ActorRef] =
+    new internals.Crimper[c.type, T](c, log).wireAnonymousActorWithProducer
+  def wireActorWithProducer_Impl[T: c.WeakTypeTag](c: blackbox.Context)(name: c.Expr[String]): c.Expr[ActorRef] =
+    new internals.Crimper[c.type, T](c, log).wireActorWithProducer(name)
+
+  def wirePropsWithFactory_Impl[T: c.WeakTypeTag](c: blackbox.Context)(factory: c.Tree): c.Expr[Props] =
+    new internals.Crimper[c.type, T](c, log).wirePropsWithFactory(factory)
+  def wireAnonymousActorWithFactory_Impl[T: c.WeakTypeTag](c: blackbox.Context)(factory: c.Tree): c.Expr[ActorRef] =
+    new internals.Crimper[c.type, T](c, log).wireAnonymousActorWithFactory(factory)
+  def wireActorWithFactory_Impl[T: c.WeakTypeTag](c: blackbox.Context)(factory: c.Tree)(
+      name: c.Expr[String]
+  ): c.Expr[ActorRef] = new internals.Crimper[c.type, T](c, log).wireActorWithFactory(factory)(name)
+}

--- a/macrosPekko/src/main/scala/com/softwaremill/macwire/pekkosupport/internals/Crimper.scala
+++ b/macrosPekko/src/main/scala/com/softwaremill/macwire/pekkosupport/internals/Crimper.scala
@@ -1,0 +1,96 @@
+package com.softwaremill.macwire.pekkosupport.internals
+
+import org.apache.pekko.actor.{ActorRef, ActorRefFactory, IndirectActorProducer, Props}
+import com.softwaremill.macwire.internals.{ConstructorCrimper, Logger, DependencyResolver}
+
+import scala.reflect.macros.blackbox
+
+private[macwire] final class Crimper[C <: blackbox.Context, T: C#WeakTypeTag](val c: C, log: Logger) {
+  import c.universe._
+  lazy val dependencyResolver = DependencyResolver.throwErrorOnResolutionFailure[c.type, Type, Tree](c, log)
+  lazy val cc = new ConstructorCrimper[c.type, T](c, new Logger)(implicitly[c.type#WeakTypeTag[T]])
+
+  lazy val targetType: Type = cc.targetType
+
+  lazy val args: List[Tree] = cc
+    .constructorArgsWithImplicitLookups(dependencyResolver)
+    .getOrElse(c.abort(c.enclosingPosition, s"Cannot find a public constructor for [$targetType]"))
+    .flatten
+
+  lazy val propsTree = q"org.apache.pekko.actor.Props(classOf[$targetType], ..$args)"
+
+  lazy val wireProps: c.Expr[Props] = log.withBlock(s"wireProps[$targetType]: at ${c.enclosingPosition}") {
+    log("Generated code: " + showRaw(propsTree))
+    c.Expr[Props](propsTree)
+  }
+
+  lazy val actorRefFactoryTree: Tree = log.withBlock("Looking for ActorRefFactory") {
+    val actorRefType = typeOf[ActorRefFactory]
+    val tree = dependencyResolver.resolve(actorRefType.typeSymbol, actorRefType)
+    log(s"Found ${showCode(tree)}")
+    tree
+  }
+
+  lazy val wireAnonymousActor: c.Expr[ActorRef] = log.withBlock(
+    s"Constructing ActorRef. Trying to find arguments for constructor of: [$targetType] at ${c.enclosingPosition}"
+  ) {
+    val tree = q"$actorRefFactoryTree.actorOf($propsTree)"
+    log("Generated code: " + showRaw(tree))
+    c.Expr[ActorRef](tree)
+  }
+
+  def wireActor(name: c.Expr[String]): c.Expr[ActorRef] =
+    log.withBlock(s"wireActor[$targetType]: at ${c.enclosingPosition}") {
+      val tree = q"$actorRefFactoryTree.actorOf($propsTree, ${name.tree})"
+      log("Generated code: " + showRaw(tree))
+      c.Expr[ActorRef](tree)
+    }
+
+  lazy val wirePropsWithProducer: c.Expr[Props] = weakTypeOf[T] match {
+    case t if t <:< typeOf[IndirectActorProducer] => wireProps
+    case _ => c.abort(c.enclosingPosition, s"wirePropsWith does not support the type: [$targetType]")
+  }
+
+  lazy val wireAnonymousActorWithProducer: c.Expr[ActorRef] = weakTypeOf[T] match {
+    case t if t <:< typeOf[IndirectActorProducer] => wireAnonymousActor
+    case _ => c.abort(c.enclosingPosition, s"wireAnonymousActorWith does not support the type: [$targetType]")
+  }
+
+  def wireActorWithProducer(name: c.Expr[String]): c.Expr[ActorRef] = weakTypeOf[T] match {
+    case t if t <:< typeOf[IndirectActorProducer] => wireActor(name)
+    case _ => c.abort(c.enclosingPosition, s"wireActorWith does not support the type: [$targetType]")
+  }
+
+  def wirePropsWithFactory(factory: c.Tree): c.Expr[Props] =
+    log.withBlock(s"wireProps[$targetType]: at ${c.enclosingPosition}") {
+      import com.softwaremill.macwire.MacwireMacros._
+
+      val funTree = wireWith_impl(c)(factory)
+      val propsTree = q"org.apache.pekko.actor.Props($funTree)"
+      log("Generated code: " + showRaw(propsTree))
+      c.Expr[Props](propsTree)
+    }
+
+  def wireAnonymousActorWithFactory(factory: c.Tree): c.Expr[ActorRef] = log.withBlock(
+    s"Constructing ActorRef. Trying to find arguments for constructor of: [$targetType] at ${c.enclosingPosition}"
+  ) {
+    import com.softwaremill.macwire.MacwireMacros._
+
+    val funTree = wireWith_impl(c)(factory)
+    val propsTree = q"org.apache.pekko.actor.Props($funTree)"
+    val tree = q"$actorRefFactoryTree.actorOf($propsTree)"
+    log("Generated code: " + showRaw(tree))
+    c.Expr[ActorRef](tree)
+  }
+
+  def wireActorWithFactory(factory: c.Tree)(name: c.Expr[String]): c.Expr[ActorRef] =
+    log.withBlock(s"wireActorWithProducer[$targetType]: at ${c.enclosingPosition}") {
+      import com.softwaremill.macwire.MacwireMacros._
+
+      val funTree = wireWith_impl(c)(factory)
+      val propsTree = q"org.apache.pekko.actor.Props($funTree)"
+      val tree = q"$actorRefFactoryTree.actorOf($propsTree, ${name.tree})"
+      log("Generated code: " + showRaw(tree))
+      c.Expr[ActorRef](tree)
+    }
+}

--- a/macrosPekko/src/main/scala/com/softwaremill/macwire/pekkosupport/package.scala
+++ b/macrosPekko/src/main/scala/com/softwaremill/macwire/pekkosupport/package.scala
@@ -1,0 +1,191 @@
+package com.softwaremill.macwire
+
+import org.apache.pekko.actor.{Actor, ActorRef, IndirectActorProducer, Props}
+
+import scala.language.experimental.macros
+
+package object pekkosupport {
+  def wireProps[T <: Actor]: Props = macro MacwirePekkoMacros.wireProps_Impl[T]
+  def wireAnonymousActor[T <: Actor]: ActorRef = macro MacwirePekkoMacros.wireAnonymousActor_Impl[T]
+  def wireActor[T <: Actor](name: String): ActorRef = macro MacwirePekkoMacros.wireActor_Impl[T]
+
+  def wirePropsWith[T]: Props = macro MacwirePekkoMacros.wirePropsWithProducer_Impl[T]
+  def wireAnonymousActorWith[T]: ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithProducer_Impl[T]
+  def wireActorWith[T](name: String): ActorRef = macro MacwirePekkoMacros.wireActorWithProducer_Impl[T]
+
+  def wirePropsWith[RES](factory: () => RES): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, RES](factory: (A) => RES): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, RES](factory: (A, B) => RES): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, RES](factory: (A, B, C) => RES): Props =
+    macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, RES](factory: (A, B, C, D) => RES): Props =
+    macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, RES](factory: (A, B, C, D, E) => RES): Props =
+    macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, RES](factory: (A, B, C, D, E, F) => RES): Props =
+    macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, RES](factory: (A, B, C, D, E, F, G) => RES): Props =
+    macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, RES](factory: (A, B, C, D, E, F, G, H) => RES): Props =
+    macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, RES](factory: (A, B, C, D, E, F, G, H, I) => RES): Props =
+    macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, RES](factory: (A, B, C, D, E, F, G, H, I, J) => RES): Props =
+    macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, K, RES](factory: (A, B, C, D, E, F, G, H, I, J, K) => RES): Props =
+    macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, K, L, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L) => RES
+  ): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, K, L, M, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M) => RES
+  ): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) => RES
+  ): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => RES
+  ): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => RES
+  ): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => RES
+  ): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => RES
+  ): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => RES
+  ): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => RES
+  ): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => RES
+  ): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+  def wirePropsWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => RES
+  ): Props = macro MacwirePekkoMacros.wirePropsWithFactory_Impl[RES]
+
+  def wireAnonymousActorWith[RES](factory: () => RES): ActorRef =
+    macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, RES](factory: (A) => RES): ActorRef =
+    macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, RES](factory: (A, B) => RES): ActorRef =
+    macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, RES](factory: (A, B, C) => RES): ActorRef =
+    macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, RES](factory: (A, B, C, D) => RES): ActorRef =
+    macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, RES](factory: (A, B, C, D, E) => RES): ActorRef =
+    macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, RES](factory: (A, B, C, D, E, F) => RES): ActorRef =
+    macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, RES](factory: (A, B, C, D, E, F, G) => RES): ActorRef =
+    macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, RES](factory: (A, B, C, D, E, F, G, H) => RES): ActorRef =
+    macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, RES](factory: (A, B, C, D, E, F, G, H, I) => RES): ActorRef =
+    macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, K, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, K, L, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+  def wireAnonymousActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => RES
+  ): ActorRef = macro MacwirePekkoMacros.wireAnonymousActorWithFactory_Impl[RES]
+
+  def wireActorWith[RES](factory: () => RES)(name: String): ActorRef =
+    macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, RES](factory: (A) => RES)(name: String): ActorRef =
+    macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, RES](factory: (A, B) => RES)(name: String): ActorRef =
+    macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, RES](factory: (A, B, C) => RES)(name: String): ActorRef =
+    macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, RES](factory: (A, B, C, D) => RES)(name: String): ActorRef =
+    macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, RES](factory: (A, B, C, D, E) => RES)(name: String): ActorRef =
+    macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, RES](factory: (A, B, C, D, E, F) => RES)(name: String): ActorRef =
+    macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, RES](factory: (A, B, C, D, E, F, G) => RES)(name: String): ActorRef =
+    macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, RES](factory: (A, B, C, D, E, F, G, H) => RES)(name: String): ActorRef =
+    macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, RES](factory: (A, B, C, D, E, F, G, H, I) => RES)(
+      name: String
+  ): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, RES](factory: (A, B, C, D, E, F, G, H, I, J) => RES)(
+      name: String
+  ): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, K, RES](factory: (A, B, C, D, E, F, G, H, I, J, K) => RES)(
+      name: String
+  ): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, K, L, RES](factory: (A, B, C, D, E, F, G, H, I, J, K, L) => RES)(
+      name: String
+  ): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M) => RES
+  )(name: String): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) => RES
+  )(name: String): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => RES
+  )(name: String): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => RES
+  )(name: String): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => RES
+  )(name: String): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => RES
+  )(name: String): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => RES
+  )(name: String): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => RES
+  )(name: String): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => RES
+  )(name: String): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+  def wireActorWith[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, RES](
+      factory: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => RES
+  )(name: String): ActorRef = macro MacwirePekkoMacros.wireActorWithFactory_Impl[RES]
+}

--- a/macrosPekkoTests/src/test/resources/test-cases/todo/wireActorWithFactory-10-makeActorInActor.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/todo/wireActorWithFactory-10-makeActorInActor.success
@@ -1,0 +1,45 @@
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing actor within actor.
+  * SomeActor is created by system but Subordinates are created as children of SomeActor.
+  *
+  */
+
+trait A
+class B
+trait C
+
+class Subordinate(a: A, b: B, c: C) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object Subordinate {
+  def get(a: A, b: B) = new Subordinate(a, b, new C{})
+}
+
+class SomeActor(a: A) extends Actor {
+
+  val b = new B {}
+
+  val subordinates: Seq[ActorRef] = (0 to 2).map { i =>
+    //subordinate factory depends on A and B which are in scope
+    wireActorWith(Subordinate.get _)(s"sub$i")
+  }
+
+  override def receive: Receive = {
+    case m => subordinates.foreach(_ ! m)
+  }
+}
+
+val system = ActorSystem("wireActorWithFactory-10-makeActorInActor")
+AfterAllTerminate(system)
+
+val a = new A {}
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey SomeActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/todo/wireAnonymousActorWithFactory-10-makeActorInActor.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/todo/wireAnonymousActorWithFactory-10-makeActorInActor.success
@@ -1,0 +1,45 @@
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing actor within actor.
+  * SomeActor is created by system but Subordinates are created as children of SomeActor.
+  *
+  */
+
+trait A
+class B
+trait C
+
+class Subordinate(a: A, b: B, c: C) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object Subordinate {
+  def get(a: A, b: B) = new Subordinate(a, b, new C{})
+}
+
+class SomeActor(a: A) extends Actor {
+
+  val b = new B {}
+
+  val subordinates: Seq[ActorRef] = (0 to 2).map { i =>
+    //subordinate factory depends on A and B which are in scope
+    wireAnonymousActorWith(Subordinate.get _)
+  }
+
+  override def receive: Receive = {
+    case m => subordinates.foreach(_ ! m)
+  }
+}
+
+val system = ActorSystem("wireAnonymousActorWithFactory-10-makeActorInActor")
+AfterAllTerminate(system)
+
+val a = new A {}
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey SomeActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/todo/wirePropsWithFactory-10-makeActorInActor.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/todo/wirePropsWithFactory-10-makeActorInActor.success
@@ -1,0 +1,47 @@
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing actor within actor.
+  * SomeActor is created by system but Subordinates are created as children of SomeActor.
+  *
+  */
+
+trait A
+class B
+trait C
+
+class Subordinate(a: A, b: B, c: C) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object Subordinate {
+  def get(a: A, b: B) = new Subordinate(a, b, new C{})
+}
+
+class SomeActor(a: A) extends Actor {
+
+  val b = new B {}
+
+  val subordinates: Seq[ActorRef] = (0 to 2).map { i =>
+    //subordinate factory depends on A and B which are in scope
+    wireAnonymousActorWith(Subordinate.get _)
+  }
+
+  override def receive: Receive = {
+    case m => subordinates.foreach(_ ! m)
+  }
+}
+
+val system = ActorSystem("wirePropsWithFactory-10-makeActorInActor")
+AfterAllTerminate(system)
+
+val a = new A {}
+
+val props: Props = wirePropsWith(SomeActor.get _)
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey SomeActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-1-simple.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-1-simple.success
@@ -1,0 +1,23 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+
+val system = ActorSystem("wireActor-1-simple")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-10-makeActorInActor.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-10-makeActorInActor.success
@@ -1,0 +1,39 @@
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing actor within actor.
+  * SomeActor is created by system but Subordinates are created as children of SomeActor.
+  *
+  */
+
+trait A
+class B
+
+class Subordinate(a: A)(b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }}
+
+class SomeActor(a: A) extends Actor {
+
+  val b = new B {}
+  val subordinates: Seq[ActorRef] = (0 to 2).map(i =>
+    //subordinate depends on A and B which are in scope
+    //ActorRefFactory comes from this.context
+    wireActor[Subordinate](s"subordinate$i")
+  )
+
+  override def receive: Receive = {
+    case m => subordinates.foreach(_ ! m)
+  }
+}
+
+val a = new A {}
+
+val system = ActorSystem("wireActor-10-makeActorInActor")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-11-toManyInjectAnnotations.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-11-toManyInjectAnnotations.failure
@@ -1,0 +1,41 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * There are to many constructors annotated with @Inject
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A) extends Actor {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  @javax.inject.Inject
+  def this(d: D) = this(new A{})
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireActor-11-toManyInjectAnnotations")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-12-noPublicConstructor.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-12-noPublicConstructor.failure
@@ -1,0 +1,42 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example SomeActor has no public constructors.
+  * Thus wireActor will not find suitable one and fail compilation.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor private (a: A) extends Actor {
+
+  private def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  private def this(c: C) = this(new A{})
+
+  @javax.inject.Inject
+  private def this(d: D) = this(new A{})
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireActor-12-noPublicConstructor")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("Bob")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-13-missingImplicitDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-13-missingImplicitDependency.failure
@@ -1,0 +1,30 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireActor-13-missingImplicitDependency")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-14-implicitParameters.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-14-implicitParameters.success
@@ -1,0 +1,30 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireActor-14-implicitParameters")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-15-injectAnnotationImplicit.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-15-injectAnnotationImplicit.success
@@ -1,0 +1,41 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wire*` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, d: D) extends Actor {
+
+  def this(b: B) = {
+    this(new A{}, new D{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C)(implicit d: D) = this(new A{}, d)
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireActor-15-injectAnnotation")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-2-manyParameterLists.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-2-manyParameterLists.success
@@ -1,0 +1,29 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireActor-2-manyParameterLists")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-3-missingDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-3-missingDependency.failure
@@ -1,0 +1,26 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor but I don't provide dependency for it.
+  * `wire*` will not find it and then not compile.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+//no dependency of type A in scope
+
+val system: ActorSystem = ActorSystem("wireActor-3-missingDependency")
+AfterAllTerminate(system)
+
+//no dependency of type A in scope
+wireActor[SomeActor]("bob")
+
+
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-3.1-missingActorRefFactoryDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-3.1-missingActorRefFactoryDependency.failure
@@ -1,0 +1,23 @@
+import org.apache.pekko.actor.Actor
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor but I don't provide dependency for it.
+  * `wire*` will not find it and then not compile.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A{}
+
+//no dependency of type ActorRefFactory in scope
+wireActor[SomeActor]("bob")
+
+
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-4-noDependenciesAtAll.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-4-noDependenciesAtAll.success
@@ -1,0 +1,19 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor without dependencies.
+  */
+
+class SomeActor extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val system = ActorSystem("wireActor-4-noDependenciesAtAll")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("Bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-5-injectAnnotation.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-5-injectAnnotation.success
@@ -1,0 +1,40 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wire*` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A) extends Actor {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+
+val system = ActorSystem("wireActor-5-injectAnnotation")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-6-injectAnnotationButNoDependencyInScope.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-6-injectAnnotationButNoDependencyInScope.failure
@@ -1,0 +1,39 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * `wire*` will look for dependencies for the constructor annotated
+  * with @Inject. Here it's missing so code will not compile.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A) extends Actor {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+//val c = new C {}
+
+val system = ActorSystem("wireActor-6-injectAnnotationButNoDependencyInScope")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-7-notActor.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-7-notActor.failure
@@ -1,0 +1,9 @@
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am trying to make props of T which is not subtype of Actor class.
+  * This will not compile.
+  */
+
+class NotActor {}
+wireActor[NotActor]

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActor-9-subtypeDependencyInScope.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActor-9-subtypeDependencyInScope.success
@@ -1,0 +1,26 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  * There is AA object which is subtype of A in scope.
+  */
+
+trait A
+trait AA extends A
+
+//TODO include cases for classes, extends A with B, objects extends trait etc
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a: AA = new AA {}
+
+val system = ActorSystem("wireActor-9-subtypeDependencyInScope")
+AfterAllTerminate(system)
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-1-simple.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-1-simple.success
@@ -1,0 +1,29 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 2 dependencies.
+  */
+
+trait A
+trait B
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A) = new SomeActor(a, new B{})
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wireActorWithFactory-1-simple")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith(SomeActor.get _)("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-12-privateMethod.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-12-privateMethod.failure
@@ -1,0 +1,26 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example SomeActor factory is a private method.
+  * Thus wireProps will not find it suitable and fail compilation.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  private def get(a: A) = new SomeActor(a)
+}
+
+val a = new A{}
+
+val system = ActorSystem("wireActorWithFactory-12-privateMethod")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith(SomeActor.get _)("bob")

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-14-implicitParameters.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-14-implicitParameters.success
@@ -1,0 +1,30 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+
+class SomeActor(a: A, b: B)(implicit c: C)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A)(implicit c: C) = new SomeActor(a, new B{})
+}
+
+val a = new A {}
+implicit val c = new C {}
+
+val system = ActorSystem("wireActorWithFactory-14-implicitParameters")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith(SomeActor.get _)("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-2-manyParameterLists.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-2-manyParameterLists.failure
@@ -1,0 +1,31 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists.
+  */
+
+trait A
+trait B
+trait C
+
+class SomeActor(a: A)(b: B, c: C) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A)(c: C) = new SomeActor(a)(new B{}, c)
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+
+val system = ActorSystem("wireActorWithFactory-2-manyParameterLists")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith(SomeActor.get _)("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-3-missingDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-3-missingDependency.failure
@@ -1,0 +1,27 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor but I don't provide dependency for it.
+  * `wireActorWithProducer` will not find it and then not compile.
+  */
+
+trait A
+trait B
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A) = new SomeActor(a, new B{})
+}
+
+//no dependency of type A in scope
+
+val system = ActorSystem("wireActorWithFactory-3-missingDependency")
+AfterAllTerminate(system)
+
+wireActorWith(SomeActor.get _)("bob")

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-4-noDependenciesAtAll.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-4-noDependenciesAtAll.success
@@ -1,0 +1,28 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor without dependencies.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get() = new SomeActor(new A{})
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wireActorWithFunction-4-noDependenciesAtAll")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith(SomeActor.get _)("bob")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-7-notActorFactory.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-7-notActorFactory.failure
@@ -1,0 +1,17 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am trying to make props with a factory returning T which is not subtype of Actor class.
+  * This will not compile.
+  */
+
+class NotActor {}
+
+object NotActor {
+  def get() = new NotActor
+}
+
+val system = ActorSystem("wireActorWithFunction-7-notActorFactory")
+
+wireActorWith(NotActor.get _)("bob")

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-9-subtypeDependencyInScope.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithFactory-9-subtypeDependencyInScope.success
@@ -1,0 +1,33 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  * There is AA object which is subtype of A in scope.
+  */
+
+trait A
+trait AA extends A
+trait B
+
+//TODO include cases for classes, extends A with B, objects extends trait etc
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A) = new SomeActor(a, new B{})
+}
+
+val a: AA = new AA {}
+lazy val b: B = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wireActorWithFactory-9-subtypeDependencyInScope")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith(SomeActor.get _)("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-1-simple.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-1-simple.success
@@ -1,0 +1,30 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 2 dependencies.
+  */
+
+trait A
+trait B
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wireActorWithProducer-1-simple")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith[SomeActorProducer]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-10-makeActorInActor.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-10-makeActorInActor.success
@@ -1,0 +1,47 @@
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing actor within actor.
+  * SomeActor is created by system but Subordinates are created as children of SomeActor.
+  *
+  */
+
+trait A
+class B
+trait C
+
+class Subordinate(a: A)(b: B, c: C) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SubordinateProducer(a: A)(b: B) extends IndirectActorProducer {
+  override def produce(): Actor = new Subordinate(a)(b, new C{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+class SomeActor(a: A) extends Actor {
+
+  val b = new B {}
+  lazy val c: C = throw new UnsupportedOperationException()
+
+  val subordinates: Seq[ActorRef] = (0 to 2).map { i =>
+    //subordinate depends on A and B which are in scope
+    wireActorWith[SubordinateProducer](s"sub$i")
+  }
+
+  override def receive: Receive = {
+    case m => subordinates.foreach(_ ! m)
+  }
+}
+
+val a = new A {}
+
+val system = ActorSystem("wireActorWithProducer-10-makeActorInActor")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-11-toManyInjectAnnotations.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-11-toManyInjectAnnotations.failure
@@ -1,0 +1,46 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * There are to many constructors annotated with @Inject
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  @javax.inject.Inject
+  def this(d: D) = this(new A{})
+
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireActorWithProducer-11-toManyInjectAnnotations")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith[SomeActorProducer]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-12-noPublicConstructor.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-12-noPublicConstructor.failure
@@ -1,0 +1,46 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example SomeActorProducer has no public constructors.
+  * Thus wireProps will not find suitable one and fail compilation.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer private (a: A) extends IndirectActorProducer {
+
+  private def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  private def this(c: C) = this(new A{})
+
+  @javax.inject.Inject
+  private def this(d: D) = this(new A{})
+
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireActorWithProducer-12-noPublicConstructor")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith[SomeActorProducer]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-13-missingImplicitDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-13-missingImplicitDependency.failure
@@ -1,0 +1,35 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer (a: A)(b: B, c: C)(implicit d: D) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a)(new B{}, c)(d)
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireActorWithProducer-13-missingImplicitDependency")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith[SomeActorProducer]("bob")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-14-implicitParameters.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-14-implicitParameters.success
@@ -1,0 +1,35 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A)(c: C)(implicit d: D) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a)(new B{}, c)(d)
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireActorWithProducer-14-implicitParameters")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith[SomeActorProducer]("bob")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-15-injectAnnotationImplicit.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-15-injectAnnotationImplicit.success
@@ -1,0 +1,45 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wire*` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, d: D) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A, d: D) extends IndirectActorProducer {
+
+  def this(b: B) = {
+    this(new A{}, new D{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C)(implicit d: D) = this(new A{}, d)
+
+  override def produce(): Actor = new SomeActor(a, d)
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireActorWithProducer-15-injectAnnotation")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith[SomeActorProducer]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-2-manyParameterLists.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-2-manyParameterLists.success
@@ -1,0 +1,34 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A)(c: C)(d: D) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a)(new B{}, c)(d)
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireActorWithProducer-2-manyParameterLists")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith[SomeActorProducer]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-3-missingDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-3-missingDependency.failure
@@ -1,0 +1,28 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor but I don't provide dependency for it.
+  * `wireActorWithProducer` will not find it and then not compile.
+  */
+
+trait A
+trait B
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+//no dependency of type A in scope
+
+val system = ActorSystem("wireActorWithProducer-3-missingDependency")
+AfterAllTerminate(system)
+
+wireActorWith[SomeActorProducer]("bob")

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-4-noDependenciesAtAll.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-4-noDependenciesAtAll.success
@@ -1,0 +1,29 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor without dependencies.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(new A{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wireActorWithProducer-4-noDependenciesAtAll")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith[SomeActorProducer]("bob")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-5-injectAnnotation.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-5-injectAnnotation.success
@@ -1,0 +1,44 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wirePropsWithProducer` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+
+val system = ActorSystem("wireActorWithProducer-5-injectAnnotation")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith[SomeActorProducer]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-6-injectAnnotationButNoDependencyInScope.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-6-injectAnnotationButNoDependencyInScope.failure
@@ -1,0 +1,44 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * `wirePropsWithProducer` will look for dependencies for the constructor annotated
+  * with @Inject. Here it's missing so code will not compile.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+//val c = new C {}
+
+val system = ActorSystem("wireActorWithProducer-6-injectAnnotationButNoDependencyInScope")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith[SomeActorProducer]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-7-notActorProducer.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-7-notActorProducer.failure
@@ -1,0 +1,10 @@
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am trying to make props of T which is not subtype of IndirectActorProducer class.
+  * This will not compile.
+  */
+
+class NotProducer {}
+
+wireActorWith[NotProducer]("bob")

--- a/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-9-subtypeDependencyInScope.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireActorWithProducer-9-subtypeDependencyInScope.success
@@ -1,0 +1,34 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  * There is AA object which is subtype of A in scope.
+  */
+
+trait A
+trait AA extends A
+trait B
+
+//TODO include cases for classes, extends A with B, objects extends trait etc
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a: AA = new AA {}
+lazy val b: B = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wireActorWithProducer-9-subtypeDependencyInScope")
+AfterAllTerminate(system)
+
+val someActor = wireActorWith[SomeActorProducer]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-1-simple.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-1-simple.success
@@ -1,0 +1,23 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+
+val system = ActorSystem("wireAnonymousActor-1-simple")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-10-makeActorInActor.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-10-makeActorInActor.success
@@ -1,0 +1,39 @@
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing actor within actor.
+  * SomeActor is created by system but Subordinates are created as children of SomeActor.
+  *
+  */
+
+trait A
+class B
+
+class Subordinate(a: A)(b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }}
+
+class SomeActor(a: A) extends Actor {
+
+  val b = new B {}
+  val subordinates: Seq[ActorRef] = (0 to 2).map(i =>
+    //subordinate depends on A and B which are in scope
+    //ActorRefFactory comes from this.context
+    wireAnonymousActor[Subordinate]
+  )
+
+  override def receive: Receive = {
+    case m => subordinates.foreach(_ ! m)
+  }
+}
+
+val a = new A {}
+
+val system = ActorSystem("wireAnonymousActor-1-makeActorInActor")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-11-toManyInjectAnnotations.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-11-toManyInjectAnnotations.failure
@@ -1,0 +1,41 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * There are to many constructors annotated with @Inject
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A) extends Actor {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  @javax.inject.Inject
+  def this(d: D) = this(new A{})
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireAnonymousActor-11-toManyInjectAnnotations")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-12-noPublicConstructor.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-12-noPublicConstructor.failure
@@ -1,0 +1,41 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example SomeActor has no public constructors.
+  * Thus wireAnonymousActor will not find suitable one and fail compilation.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor private (a: A) extends Actor {
+
+  private def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  private def this(c: C) = this(new A{})
+
+  @javax.inject.Inject
+  private def this(d: D) = this(new A{})
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireAnonymousActor-12-noPublicConstructor")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-13-missingImplicitDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-13-missingImplicitDependency.failure
@@ -1,0 +1,30 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireAnonymousActor-13-missingImplicitDependency")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-14-implicitParameters.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-14-implicitParameters.success
@@ -1,0 +1,30 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireAnonymousActor-14-implicitParameters")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-15-injectAnnotationImplicit.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-15-injectAnnotationImplicit.success
@@ -1,0 +1,41 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wire*` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, d: D) extends Actor {
+
+  def this(b: B) = {
+    this(new A{}, new D{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C)(implicit d: D) = this(new A{}, d)
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireAnonymousActor-15-injectAnnotation")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-2-manyParameterLists.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-2-manyParameterLists.success
@@ -1,0 +1,30 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireAnonymousActor-2-manyParameterLists")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-3-missingDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-3-missingDependency.failure
@@ -1,0 +1,23 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor but I don't provide dependency for it.
+  * `wire*` will not find it and then not compile.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val system: ActorSystem = ActorSystem("wireAnonymousActor-3-missingDependency")
+AfterAllTerminate(system)
+
+//no dependency of type A in scope
+wireAnonymousActor[SomeActor]
+
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-3.1-missingActorRefFactoryDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-3.1-missingActorRefFactoryDependency.failure
@@ -1,0 +1,22 @@
+import org.apache.pekko.actor.Actor
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor but I don't provide dependency for it.
+  * `wire*` will not find it and then not compile.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+
+//no dependency of type ActorRefFactory in scope
+wireAnonymousActor[SomeActor]
+
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-4-noDependenciesAtAll.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-4-noDependenciesAtAll.success
@@ -1,0 +1,19 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor without dependencies.
+  */
+
+class SomeActor extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val system = ActorSystem("wireAnonymousActor-4-noDependenciesAtAll")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-5-injectAnnotation.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-5-injectAnnotation.success
@@ -1,0 +1,39 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wire*` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A) extends Actor {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+
+val system = ActorSystem("wireAnonymousActor-5-injectAnnotation")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-6-injectAnnotationButNoDependencyInScope.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-6-injectAnnotationButNoDependencyInScope.failure
@@ -1,0 +1,39 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * `wire*` will look for dependencies for the constructor annotated
+  * with @Inject. Here it's missing so code will not compile.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A) extends Actor {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+//val c = new C {}
+
+val system = ActorSystem("wireAnonymous-6-injectAnnotationButNoDependencyInScope")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-7-notActor.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-7-notActor.failure
@@ -1,0 +1,9 @@
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am trying to make props of T which is not subtype of Actor class.
+  * This will not compile.
+  */
+
+class NotActor {}
+wireAnonymousActor[NotActor]

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-9-subtypeDependencyInScope.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActor-9-subtypeDependencyInScope.success
@@ -1,0 +1,27 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  * There is AA object which is subtype of A in scope.
+  */
+
+trait A
+trait AA extends A
+
+//TODO include cases for classes, extends A with B, objects extends trait etc
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a: AA = new AA {}
+
+val system = ActorSystem("wireActor-1-simple")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-1-simple.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-1-simple.success
@@ -1,0 +1,29 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 2 dependencies.
+  */
+
+trait A
+trait B
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A) = new SomeActor(a, new B{})
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wireAnonymousActorWithFactory-1-simple")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith(SomeActor.get _)
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-12-privateMethod.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-12-privateMethod.failure
@@ -1,0 +1,26 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example SomeActor factory is a private method.
+  * Thus wireProps will not find it suitable and fail compilation.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  private def get(a: A) = new SomeActor(a)
+}
+
+val a = new A{}
+
+val system = ActorSystem("wireAnonymousActorWithFactory-12-privateMethod")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith(SomeActor.get _)

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-14-implicitParameters.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-14-implicitParameters.success
@@ -1,0 +1,30 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+
+class SomeActor(a: A, b: B)(implicit c: C)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A)(implicit c: C) = new SomeActor(a, new B{})
+}
+
+val a = new A {}
+implicit val c = new C {}
+
+val system = ActorSystem("wireAnonymousActorWithFactory-14-implicitParameters")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith(SomeActor.get _)
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-2-manyParameterLists.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-2-manyParameterLists.failure
@@ -1,0 +1,31 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists.
+  */
+
+trait A
+trait B
+trait C
+
+class SomeActor(a: A)(b: B, c: C) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A)(c: C) = new SomeActor(a)(new B{}, c)
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+
+val system = ActorSystem("wireAnonymousActorWithFactory-2-manyParameterLists")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith(SomeActor.get _)
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-3-missingDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-3-missingDependency.failure
@@ -1,0 +1,27 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor but I don't provide dependency for it.
+  * `wireActorWithProducer` will not find it and then not compile.
+  */
+
+trait A
+trait B
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A) = new SomeActor(a, new B{})
+}
+
+//no dependency of type A in scope
+
+val system = ActorSystem("wireAnonymousActorWithFactory-3-missingDependency")
+AfterAllTerminate(system)
+
+wireAnonymousActorWith(SomeActor.get _)

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-4-noDependenciesAtAll.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-4-noDependenciesAtAll.success
@@ -1,0 +1,28 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor without dependencies.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get() = new SomeActor(new A{})
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wireAnonymousActorWithFactory-4-noDependenciesAtAll")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith(SomeActor.get _)
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-7-notActorFactory.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-7-notActorFactory.failure
@@ -1,0 +1,17 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am trying to make props with a factory returning T which is not subtype of Actor class.
+  * This will not compile.
+  */
+
+class NotActor {}
+
+object NotActor {
+  def get() = new NotActor
+}
+
+val system = ActorSystem("wireAnonymousActorWithFactory-7-notActorFactory")
+
+wireAnonymousActorWith(NotActor.get _)

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-9-subtypeDependencyInScope.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithFactory-9-subtypeDependencyInScope.success
@@ -1,0 +1,33 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  * There is AA object which is subtype of A in scope.
+  */
+
+trait A
+trait AA extends A
+trait B
+
+//TODO include cases for classes, extends A with B, objects extends trait etc
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A) = new SomeActor(a, new B{})
+}
+
+val system = ActorSystem("wireAnonymousActorWithFactory-9-subtypeDependencyInScope")
+AfterAllTerminate(system)
+
+val a: AA = new AA {}
+lazy val b: B = throw new UnsupportedOperationException()
+
+val someActor = wireAnonymousActorWith(SomeActor.get _)
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-1-simple.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-1-simple.success
@@ -1,0 +1,30 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 2 dependencies.
+  */
+
+trait A
+trait B
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wireAnonymousActorWithProducer-1-simple")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith[SomeActorProducer]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-10-makeActorInActor.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-10-makeActorInActor.success
@@ -1,0 +1,47 @@
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing actor within actor.
+  * SomeActor is created by system but Subordinates are created as children of SomeActor.
+  *
+  */
+
+trait A
+class B
+trait C
+
+class Subordinate(a: A)(b: B, c: C) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SubordinateProducer(a: A)(b: B) extends IndirectActorProducer {
+  override def produce(): Actor = new Subordinate(a)(b, new C{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+class SomeActor(a: A) extends Actor {
+
+  val b = new B {}
+  lazy val c: C = throw new UnsupportedOperationException()
+
+  val subordinates: Seq[ActorRef] = (0 to 2).map { i =>
+    //subordinate depends on A and B which are in scope
+    wireAnonymousActorWith[SubordinateProducer]
+  }
+
+  override def receive: Receive = {
+    case m => subordinates.foreach(_ ! m)
+  }
+}
+
+val a = new A {}
+
+val system = ActorSystem("wireAnonymousActorWithProducer-10-makeActorInActor")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-11-toManyInjectAnnotations.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-11-toManyInjectAnnotations.failure
@@ -1,0 +1,46 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * There are to many constructors annotated with @Inject
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  @javax.inject.Inject
+  def this(d: D) = this(new A{})
+
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireAnonymousActorWithProducer-11-toManyInjectAnnotations")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith[SomeActorProducer]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-12-noPublicConstructor.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-12-noPublicConstructor.failure
@@ -1,0 +1,46 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example SomeActorProducer has no public constructors.
+  * Thus wireProps will not find suitable one and fail compilation.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer private (a: A) extends IndirectActorProducer {
+
+  private def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  private def this(c: C) = this(new A{})
+
+  @javax.inject.Inject
+  private def this(d: D) = this(new A{})
+
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireAnonymousActorWithProducer-12-noPublicConstructor")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith[SomeActorProducer]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-13-missingImplicitDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-13-missingImplicitDependency.failure
@@ -1,0 +1,35 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer (a: A)(b: B, c: C)(implicit d: D) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a)(new B{}, c)(d)
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireAnonymousActorWithProducer-13-missingImplicitDependency")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith[SomeActorProducer]
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-14-implicitParameters.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-14-implicitParameters.success
@@ -1,0 +1,35 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A)(c: C)(implicit d: D) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a)(new B{}, c)(d)
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireAnonymousActorWithProducer-14-implicitParameters")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith[SomeActorProducer]
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-15-injectAnnotationImplicit.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-15-injectAnnotationImplicit.success
@@ -1,0 +1,45 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wire*` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, d: D) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A, d: D) extends IndirectActorProducer {
+
+  def this(b: B) = {
+    this(new A{}, new D{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C)(implicit d: D) = this(new A{}, d)
+
+  override def produce(): Actor = new SomeActor(a, d)
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireAnonymousActorWithProducer-15-injectAnnotation")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith[SomeActorProducer]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-2-manyParameterLists.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-2-manyParameterLists.success
@@ -1,0 +1,34 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A)(c: C)(d: D) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a)(new B{}, c)(d)
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireAnonymousActorWithProducer-2-manyParameterLists")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith[SomeActorProducer]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-3-missingDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-3-missingDependency.failure
@@ -1,0 +1,28 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor but I don't provide dependency for it.
+  * `wireActorWithProducer` will not find it and then not compile.
+  */
+
+trait A
+trait B
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+//no dependency of type A in scope
+
+val system = ActorSystem("wireAnonymousActorWithProducer-3-missingDependency")
+AfterAllTerminate(system)
+
+wireAnonymousActorWith[SomeActorProducer]

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-4-noDependenciesAtAll.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-4-noDependenciesAtAll.success
@@ -1,0 +1,29 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor without dependencies.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(new A{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wireAnonymousActorWithProducer-4-noDependenciesAtAll")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith[SomeActorProducer]
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-5-injectAnnotation.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-5-injectAnnotation.success
@@ -1,0 +1,44 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wirePropsWithProducer` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+
+val system = ActorSystem("wireAnonymousActorWithProducer-5-injectAnnotation")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith[SomeActorProducer]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-6-injectAnnotationButNoDependencyInScope.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-6-injectAnnotationButNoDependencyInScope.failure
@@ -1,0 +1,44 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * `wirePropsWithProducer` will look for dependencies for the constructor annotated
+  * with @Inject. Here it's missing so code will not compile.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+//val c = new C {}
+
+val system = ActorSystem("wireAnonymousActorWithProducer-6-injectAnnotationButNoDependencyInScope")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith[SomeActorProducer]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-7-notActorProducer.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-7-notActorProducer.failure
@@ -1,0 +1,10 @@
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am trying to make props of T which is not subtype of IndirectActorProducer class.
+  * This will not compile.
+  */
+
+class NotProducer {}
+
+wireAnonymousActorWith[NotProducer]

--- a/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-9-subtypeDependencyInScope.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireAnonymousActorWithProducer-9-subtypeDependencyInScope.success
@@ -1,0 +1,34 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  * There is AA object which is subtype of A in scope.
+  */
+
+trait A
+trait AA extends A
+trait B
+
+//TODO include cases for classes, extends A with B, objects extends trait etc
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a: AA = new AA {}
+lazy val b: B = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wireAnonymousActorWithProducer-9-subtypeDependencyInScope")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActorWith[SomeActorProducer]
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-1-simple.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-1-simple.success
@@ -1,0 +1,25 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+
+val system = ActorSystem("wireProps-1-simple")
+AfterAllTerminate(system)
+
+val props: Props = wireProps[SomeActor]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-10-makeActorInActor.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-10-makeActorInActor.success
@@ -1,0 +1,39 @@
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing actor within actor.
+  * SomeActor is created by system but Subordinates are created as children of SomeActor.
+  *
+  */
+
+trait A
+class B
+
+class Subordinate(a: A)(b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActor(a: A) extends Actor {
+
+  val b = new B {}
+  val subordinates: Seq[ActorRef] = (0 to 2).map(i =>
+    //subordinate depends on A and B which are in scope
+    context.actorOf(wireProps[Subordinate], s"sub$i")
+  )
+
+  override def receive: Receive = {
+    case m => subordinates.foreach(_ ! m)
+  }
+}
+
+val a = new A {}
+
+val system = ActorSystem("wireProps-10-makeActorInActor")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-11-toManyInjectAnnotations.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-11-toManyInjectAnnotations.failure
@@ -1,0 +1,43 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * There are to many constructors annotated with @Inject
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A) extends Actor {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  @javax.inject.Inject
+  def this(d: D) = this(new A{})
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireProps-11-toManyInjectAnnotations")
+AfterAllTerminate(system)
+
+val props: Props = wireProps[SomeActor]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-12-noPublicConstructor.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-12-noPublicConstructor.failure
@@ -1,0 +1,41 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example SomeActor has no public constructors.
+  * Thus wireProps will not find suitable one and fail compilation.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor private (a: A) extends Actor {
+
+  private def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  private def this(c: C) = this(new A{})
+
+  @javax.inject.Inject
+  private def this(d: D) = this(new A{})
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireProps-12-noPublicConstructor")
+AfterAllTerminate(system)
+
+val someActor = system.actorOf(wireProps[SomeActor], "bob")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-13-missingImplicitDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-13-missingImplicitDependency.failure
@@ -1,0 +1,32 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireProps-13-missingImplicitDependency")
+AfterAllTerminate(system)
+
+val props: Props = wireProps[SomeActor]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-14-implicitParameters.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-14-implicitParameters.success
@@ -1,0 +1,32 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireProps-14-implicitParameters")
+AfterAllTerminate(system)
+
+val props: Props = wireProps[SomeActor]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-15-injectAnnotationImplicit.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-15-injectAnnotationImplicit.success
@@ -1,0 +1,43 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wire*` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, d: D) extends Actor {
+
+  def this(b: B) = {
+    this(new A{}, new D{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C)(implicit d: D) = this(new A{}, d)
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireActor-15-injectAnnotation")
+AfterAllTerminate(system)
+
+val props: Props = wireProps[SomeActor]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-2-manyParameterLists.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-2-manyParameterLists.success
@@ -1,0 +1,32 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireProps-2-manyParameterLists")
+AfterAllTerminate(system)
+
+val props: Props = wireProps[SomeActor]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-3-missingDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-3-missingDependency.failure
@@ -1,0 +1,21 @@
+import org.apache.pekko.actor.Actor
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor but I don't provide dependency for it.
+  * `wireProps` will not find it and then not compile.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+//no dependency of type A in scope
+
+wireProps[SomeActor]
+
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-4-noDependenciesAtAll.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-4-noDependenciesAtAll.success
@@ -1,0 +1,22 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor without dependencies.
+  */
+
+class SomeActor extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val system = ActorSystem("wireProps-4-noDependenciesAtAll")
+AfterAllTerminate(system)
+
+val props: Props = wireProps[SomeActor]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-5-injectAnnotation.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-5-injectAnnotation.success
@@ -1,0 +1,41 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wireProps` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A) extends Actor {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+
+val system = ActorSystem("wireProps-5-injectAnnotation")
+AfterAllTerminate(system)
+
+val props: Props = wireProps[SomeActor]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-6-injectAnnotationButNoDependencyInScope.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-6-injectAnnotationButNoDependencyInScope.failure
@@ -1,0 +1,41 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * `wireProps` will look for dependencies for the constructor annotated
+  * with @Inject. Here it's missing so code will not compile.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A) extends Actor {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+//val c = new C {}
+
+val system = ActorSystem("wireProps-6-injectAnnotationButNoDependencyInScope")
+AfterAllTerminate(system)
+
+val props: Props = wireProps[SomeActor]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-7-notActor.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-7-notActor.failure
@@ -1,0 +1,10 @@
+import org.apache.pekko.actor.Props
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am trying to make props of T which is not subtype of Actor class.
+  * This will not compile.
+  */
+
+class NotActor {}
+val props: Props = wireProps[NotActor]

--- a/macrosPekkoTests/src/test/resources/test-cases/wireProps-9-subtypeDependencyInScope.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wireProps-9-subtypeDependencyInScope.success
@@ -1,0 +1,27 @@
+import org.apache.pekko.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  * There is AA object which is subtype of A in scope.
+  */
+
+trait A
+trait AA extends A
+
+//TODO include cases for classes, extends A with B, objects extends trait etc
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a: AA = new AA {}
+
+val system = ActorSystem("wireProps-9-subtypeDependencyInScope")
+AfterAllTerminate(system)
+
+val someActor = system.actorOf(wireProps[SomeActor], "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-1-simple.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-1-simple.success
@@ -1,0 +1,31 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 2 dependencies.
+  */
+
+trait A
+trait B
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A) = new SomeActor(a, new B{})
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wirePropsWithFactory-1-simple")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith(SomeActor.get _)
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-12-privateMethod.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-12-privateMethod.failure
@@ -1,0 +1,26 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example SomeActor factory is a private method.
+  * Thus wireProps will not find it suitable and fail compilation.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  private def get(a: A) = new SomeActor(a)
+}
+
+val a = new A{}
+
+val system = ActorSystem("wirePropsWithFactory-12-privateMethod")
+AfterAllTerminate(system)
+
+val someActor = wirePropsWith(SomeActor.get _)

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-14-implicitParameters.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-14-implicitParameters.success
@@ -1,0 +1,32 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+
+class SomeActor(a: A, b: B)(implicit c: C)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A)(implicit c: C) = new SomeActor(a, new B{})
+}
+
+val a = new A {}
+implicit val c = new C {}
+
+val system = ActorSystem("wirePropsWithFactory-14-implicitParameters")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith(SomeActor.get _)
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-2-manyParameterLists.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-2-manyParameterLists.failure
@@ -1,0 +1,33 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists.
+  */
+
+trait A
+trait B
+trait C
+
+class SomeActor(a: A)(b: B, c: C) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A)(c: C) = new SomeActor(a)(new B{}, c)
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+
+val system = ActorSystem("wirePropsWithFactory-2-manyParameterLists")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith(SomeActor.get _)
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-3-missingDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-3-missingDependency.failure
@@ -1,0 +1,27 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor but I don't provide dependency for it.
+  * `wireActorWithProducer` will not find it and then not compile.
+  */
+
+trait A
+trait B
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A) = new SomeActor(a, new B{})
+}
+
+//no dependency of type A in scope
+
+val system = ActorSystem("wirePropsWithFactory-3-missingDependency")
+AfterAllTerminate(system)
+
+wirePropsWith(SomeActor.get _)

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-4-noDependenciesAtAll.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-4-noDependenciesAtAll.success
@@ -1,0 +1,29 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor without dependencies.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get() = new SomeActor(new A{})
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wirePropsWithFactory-4-noDependenciesAtAll")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith(SomeActor.get _)
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-7-notActorFactory.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-7-notActorFactory.failure
@@ -1,0 +1,17 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am trying to make props with a factory returning T which is not subtype of Actor class.
+  * This will not compile.
+  */
+
+class NotActor {}
+
+object NotActor {
+  def get() = new NotActor
+}
+
+val system = ActorSystem("wirePropsWithFactory-7-notActorFactory")
+
+wirePropsWith(NotActor.get _)

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-9-subtypeDependencyInScope.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithFactory-9-subtypeDependencyInScope.success
@@ -1,0 +1,35 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  * There is AA object which is subtype of A in scope.
+  */
+
+trait A
+trait AA extends A
+trait B
+
+//TODO include cases for classes, extends A with B, objects extends trait etc
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+object SomeActor {
+  def get(a: A) = new SomeActor(a, new B{})
+}
+
+val a: AA = new AA {}
+lazy val b: B = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wirePropsWithFactory-9-subtypeDependencyInScope")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith(SomeActor.get _)
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-1-simple.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-1-simple.success
@@ -1,0 +1,32 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  */
+
+trait A
+trait B
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wirePropsWithProducer-1-simple")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith[SomeActorProducer]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-10-makeActorInActor.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-10-makeActorInActor.success
@@ -1,0 +1,48 @@
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, IndirectActorProducer, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing actor within actor.
+  * SomeActor is created by system but Subordinates are created as children of SomeActor.
+  *
+  */
+
+trait A
+class B
+trait C
+
+class Subordinate(a: A)(b: B, c: C) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SubordinateProducer(a: A)(b: B) extends IndirectActorProducer {
+  override def produce(): Actor = new Subordinate(a)(b, new C{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+class SomeActor(a: A) extends Actor {
+
+  val b = new B {}
+  lazy val c: C = throw new UnsupportedOperationException()
+
+  val subordinates: Seq[ActorRef] = (0 to 2).map { i =>
+    //subordinate depends on A and B which are in scope
+    val props: Props = wirePropsWith[SubordinateProducer]
+    context.actorOf(props, s"sub$i")
+  }
+
+  override def receive: Receive = {
+    case m => subordinates.foreach(_ ! m)
+  }
+}
+
+val a = new A {}
+
+val system = ActorSystem("wirePropsWithProducer-10-makeActorInActor")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-11-toManyInjectAnnotations.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-11-toManyInjectAnnotations.failure
@@ -1,0 +1,49 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * There are to many constructors annotated with @Inject
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  @javax.inject.Inject
+  def this(d: D) = this(new A{})
+
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wirePropsWithProducer-11-toManyInjectAnnotations")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith[SomeActorProducer]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-12-noPublicConstructor.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-12-noPublicConstructor.failure
@@ -1,0 +1,48 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example SomeActorProducer has no public constructors.
+  * Thus wireProps will not find suitable one and fail compilation.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer private (a: A) extends IndirectActorProducer {
+
+  private def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  private def this(c: C) = this(new A{})
+
+  @javax.inject.Inject
+  private def this(d: D) = this(new A{})
+
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wirePropsWithProducer-12-noPublicConstructor")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith[SomeActorProducer]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-13-missingImplicitDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-13-missingImplicitDependency.failure
@@ -1,0 +1,37 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer (a: A)(b: B, c: C)(implicit d: D) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a)(new B{}, c)(d)
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wirePropsWithProducer-13-missingImplicitDependency")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith[SomeActorProducer]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-14-implicitParameters.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-14-implicitParameters.success
@@ -1,0 +1,37 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A)(c: C)(implicit d: D) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a)(new B{}, c)(d)
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wirePropsWithProducer-14-implicitParameters")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith[SomeActorProducer]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-15-injectAnnotationImplicit.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-15-injectAnnotationImplicit.success
@@ -1,0 +1,48 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wire*` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, d: D) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A, d: D) extends IndirectActorProducer {
+
+  def this(b: B) = {
+    this(new A{}, new D{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C)(implicit d: D) = this(new A{}, d)
+
+  override def produce(): Actor = new SomeActor(a, d)
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wirePropsWithProducer-15-injectAnnotation")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith[SomeActorProducer]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-2-manyParameterLists.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-2-manyParameterLists.success
@@ -1,0 +1,36 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A)(c: C)(d: D) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a)(new B{}, c)(d)
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a = new A {}
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wirePropsWithProducer-2-manyParameterLists")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith[SomeActorProducer]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-3-missingDependency.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-3-missingDependency.failure
@@ -1,0 +1,25 @@
+import org.apache.pekko.actor.{Actor, IndirectActorProducer}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor but I don't provide dependency for it.
+  * `wirePropsWithProducer` will not find it and then not compile.
+  */
+
+trait A
+trait B
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+//no dependency of type A in scope
+
+wirePropsWith[SomeActorProducer]

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-4-noDependenciesAtAll.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-4-noDependenciesAtAll.success
@@ -1,0 +1,31 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor without dependencies.
+  */
+
+trait A
+
+class SomeActor(a: A) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(new A{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wirePropsWithProducer-4-noDependenciesAtAll")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith[SomeActorProducer]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"
+

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-5-injectAnnotation.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-5-injectAnnotation.success
@@ -1,0 +1,46 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wirePropsWithProducer` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+
+val system = ActorSystem("wirePropsWithProducer-5-injectAnnotation")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith[SomeActorProducer]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-6-injectAnnotationButNoDependencyInScope.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-6-injectAnnotationButNoDependencyInScope.failure
@@ -1,0 +1,46 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * `wirePropsWithProducer` will look for dependencies for the constructor annotated
+  * with @Inject. Here it's missing so code will not compile.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+
+  def this(b: B) = {
+    this(new A{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C) = this(new A{})
+
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+//val c = new C {}
+
+val system = ActorSystem("wirePropsWithProducer-6-injectAnnotationButNoDependencyInScope")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith[SomeActorProducer]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-7-notActorProducer.failure
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-7-notActorProducer.failure
@@ -1,0 +1,10 @@
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am trying to make props of T which is not subtype of IndirectActorProducer class.
+  * This will not compile.
+  */
+
+class NotProducer {}
+
+wirePropsWith[NotProducer]

--- a/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-9-subtypeDependencyInScope.success
+++ b/macrosPekkoTests/src/test/resources/test-cases/wirePropsWithProducer-9-subtypeDependencyInScope.success
@@ -1,0 +1,36 @@
+import org.apache.pekko.actor.{Actor, ActorSystem, IndirectActorProducer, Props}
+import com.softwaremill.macwire.pekkosupport._
+
+/**
+  * In this example I am constructing simple actor with 1 dependency.
+  * There is AA object which is subtype of A in scope.
+  */
+
+trait A
+trait AA extends A
+trait B
+
+//TODO include cases for classes, extends A with B, objects extends trait etc
+
+class SomeActor(a: A, b: B) extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+class SomeActorProducer(a: A) extends IndirectActorProducer {
+  override def produce(): Actor = new SomeActor(a, new B{})
+  override def actorClass: Class[_ <: Actor] = classOf[SomeActor]
+}
+
+val a: AA = new AA {}
+lazy val b: B = throw new UnsupportedOperationException()
+
+val system = ActorSystem("wirePropsWithProducer-9-subtypeDependencyInScope")
+AfterAllTerminate(system)
+
+val props: Props = wirePropsWith[SomeActorProducer]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"

--- a/macrosPekkoTests/src/test/scala/com/softwaremill/macwire/pekkosupport/AfterAllTerminate.scala
+++ b/macrosPekkoTests/src/test/scala/com/softwaremill/macwire/pekkosupport/AfterAllTerminate.scala
@@ -1,0 +1,33 @@
+package com.softwaremill.macwire.pekkosupport
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.dispatch.MonitorableThreadFactory
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object AfterAllTerminate {
+
+  /**
+    * We need to terminate ActorSystem.
+    * It can be done in test script in last line by simply calling `system.terminate()`.
+    * However above solution can terminate the `actorSystem` sooner than all messages are being delivered.
+    * That will result in ugly messages in test logs which are not related to bugs:
+    *
+    * {{{[INFO] [01/31/2017 19:33:21.407] [wireProps-9-subtypeDependencyInScope-org.apache.pekko.actor.default-dispatcher-6] [org.apache.pekko://wireProps-9-subtypeDependencyInScope/user/someActor] Message [java.lang.String] from Actor[org.apache.pekko://wireProps-9-subtypeDependencyInScope/deadLetters] to Actor[org.apache.pekko://wireProps-9-subtypeDependencyInScope/user/someActor#-2046131540] was not delivered. [1] dead letters encountered. This logging can be turned off or adjusted with configuration settings 'org.apache.pekko.log-dead-letters' and 'org.apache.pekko.log-dead-letters-during-shutdown'.[info] wireActor-11-toManyInjectAnnotations.failure}}}
+    *
+    * If we terminate `ActorSystem` using this hook the system will be terminated after all messages
+    * are being delivered. Logs become cleaner.
+    */
+  def apply(system: ActorSystem): Unit = Runtime.getRuntime.addShutdownHook(
+    MonitorableThreadFactory(
+      name = "monitoring-thread-factory",
+      daemonic = false,
+      contextClassLoader = Some(Thread.currentThread().getContextClassLoader)).newThread(new Runnable {
+      override def run(): Unit = {
+        val terminate = system.terminate()
+        Await.result(terminate, 10.seconds)
+      }
+    })
+  )
+
+}

--- a/macrosPekkoTests/src/test/scala/com/softwaremill/macwire/pekkosupport/CompileTests.scala
+++ b/macrosPekkoTests/src/test/scala/com/softwaremill/macwire/pekkosupport/CompileTests.scala
@@ -1,0 +1,62 @@
+package com.softwaremill.macwire.pekkosupport
+
+import com.softwaremill.macwire.CompileTestsSupport
+
+class CompileTests extends CompileTestsSupport {
+
+  runTestsWith(
+    expectedFailures = List(
+      "wireProps-3-missingDependency" -> List("Cannot find a value of type: [A]"),
+      "wireAnonymousActor-3-missingDependency" -> List("Cannot find a value of type: [A]"),
+      "wireActor-3-missingDependency" -> List("Cannot find a value of type: [A]"),
+      "wireAnonymousActor-3.1-missingActorRefFactoryDependency" -> List("Cannot find a value of type: [org.apache.pekko.actor.ActorRefFactory]"),
+      "wireActor-3.1-missingActorRefFactoryDependency" -> List("Cannot find a value of type: [org.apache.pekko.actor.ActorRefFactory]"),
+      "wireProps-6-injectAnnotationButNoDependencyInScope" -> List("Cannot find a value of type: [C]"),
+      "wireAnonymousActor-6-injectAnnotationButNoDependencyInScope" -> List("Cannot find a value of type: [C]"),
+      "wireActor-6-injectAnnotationButNoDependencyInScope" -> List("Cannot find a value of type: [C]"),
+      "wireProps-7-notActor" -> List("type arguments [NotActor] do not conform to macro method wireProps's type parameter bounds [T <: org.apache.pekko.actor.Actor]"),
+      "wireAnonymousActor-7-notActor" -> List("type arguments [NotActor] do not conform to macro method wireAnonymousActor's type parameter bounds [T <: org.apache.pekko.actor.Actor]"),
+      "wireActor-7-notActor" -> List("type arguments [NotActor] do not conform to macro method wireActor's type parameter bounds [T <: org.apache.pekko.actor.Actor]"),
+      "wireProps-11-toManyInjectAnnotations" -> List("Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActor]"),
+      "wireAnonymousActor-11-toManyInjectAnnotations" -> List("Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActor]"),
+      "wireActor-11-toManyInjectAnnotations" -> List("Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActor]"),
+      "wireProps-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActor]"),
+      "wireAnonymousActor-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActor]"),
+      "wireActor-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActor]"),
+      "wireActor-13-missingImplicitDependency" -> List("could not find implicit value for parameter e: D"),
+      "wireAnonymousActor-13-missingImplicitDependency" -> List("could not find implicit value for parameter e: D"),
+      "wireProps-13-missingImplicitDependency" -> List("could not find implicit value for parameter e: D"),
+      "wireActorWithFactory-2-manyParameterLists" -> List("Not supported factory type: "),
+      "wireActorWithFactory-3-missingDependency" -> List("Cannot find a value of type: [A]"),
+      "wireActorWithFactory-7-notActorFactory" -> List("overloaded method", "apply with alternatives:", "cannot be applied to (NotActor)"),
+      "wireActorWithFactory-12-privateMethod" -> List("method get in object SomeActor cannot be accessed"),
+      "wireActorWithProducer-3-missingDependency" -> List("Cannot find a value of type: [A]"),
+      "wireActorWithProducer-6-injectAnnotationButNoDependencyInScope" -> List("Cannot find a value of type: [C]"),
+      "wireActorWithProducer-7-notActorProducer" -> List("wireActorWith does not support the type: [NotProducer]"),
+      "wireActorWithProducer-11-toManyInjectAnnotations" -> List("Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActorProducer]"),
+      "wireActorWithProducer-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActorProducer]"),
+      "wireActorWithProducer-13-missingImplicitDependency" -> List("could not find implicit value for parameter e: D"),
+      "wireAnonymousActorWithFactory-2-manyParameterLists" -> List("Not supported factory type: "),
+      "wireAnonymousActorWithFactory-3-missingDependency" -> List("Cannot find a value of type: [A]"),
+      "wireAnonymousActorWithFactory-7-notActorFactory" -> List("overloaded method", "apply with alternatives:", "cannot be applied to (NotActor)"),
+      "wireAnonymousActorWithFactory-12-privateMethod" -> List("method get in object SomeActor cannot be accessed"),
+      "wireAnonymousActorWithProducer-3-missingDependency" -> List("Cannot find a value of type: [A]"),
+      "wireAnonymousActorWithProducer-6-injectAnnotationButNoDependencyInScope" -> List("Cannot find a value of type: [C]"),
+      "wireAnonymousActorWithProducer-7-notActorProducer" -> List("wireAnonymousActorWith does not support the type: [NotProducer]"),
+      "wireAnonymousActorWithProducer-11-toManyInjectAnnotations" -> List("Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActorProducer]"),
+      "wireAnonymousActorWithProducer-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActorProducer]"),
+      "wireAnonymousActorWithProducer-13-missingImplicitDependency" -> List("could not find implicit value for parameter e: D"),
+      "wirePropsWithFactory-2-manyParameterLists" -> List("Not supported factory type: "),
+      "wirePropsWithFactory-3-missingDependency" -> List("Cannot find a value of type: [A]"),
+      "wirePropsWithFactory-7-notActorFactory" -> List("overloaded method", "apply with alternatives:", "cannot be applied to (NotActor)"),
+      "wirePropsWithFactory-12-privateMethod" -> List("method get in object SomeActor cannot be accessed"),
+      "wirePropsWithProducer-3-missingDependency" -> List("Cannot find a value of type: [A]"),
+      "wirePropsWithProducer-6-injectAnnotationButNoDependencyInScope" -> List("Cannot find a value of type: [C]"),
+      "wirePropsWithProducer-7-notActorProducer" -> List("wirePropsWith does not support the type: [NotProducer]"),
+      "wirePropsWithProducer-11-toManyInjectAnnotations" -> List("Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActorProducer]"),
+      "wirePropsWithProducer-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActorProducer]"),
+      "wirePropsWithProducer-13-missingImplicitDependency" -> List("could not find implicit value for parameter e: D")
+    ),
+    expectedWarnings = List()
+  )
+}

--- a/macrosPekkoTests/src/test/scala/com/softwaremill/macwire/pekkosupport/demo/Demo.scala
+++ b/macrosPekkoTests/src/test/scala/com/softwaremill/macwire/pekkosupport/demo/Demo.scala
@@ -1,0 +1,92 @@
+package com.softwaremill.macwire.pekkosupport.demo
+
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem}
+import org.apache.pekko.routing.RoundRobinPool
+import com.softwaremill.macwire._
+import com.softwaremill.macwire.pekkosupport._
+import com.softwaremill.tagging._
+
+object Demo extends App {
+
+  val system = ActorSystem("Demo")
+
+  val score = new Score {}
+
+  val violin: ActorRef @@ Violin = wireAnonymousActor[ViolinActor].taggedWith[Violin]
+  val guitar: ActorRef @@ Guitar = wireAnonymousActor[GuitarActor].taggedWith[Guitar]
+
+  val aliceSinger: ActorRef @@ Singer = wireActor[SingerActor]("alice").taggedWith[Singer]
+  val bobSinger: ActorRef @@ Singer = wireActor[SingerActor]("bob").taggedWith[Singer]
+  val bertaSinger = wireActor[SingerActor]("berta").taggedWith[Singer]
+  val singers = wireSet[ActorRef @@ Singer]
+
+  val `4 voices polyphone` = system.actorOf(wireProps[PolyphoneActor].withRouter(RoundRobinPool(4))).taggedWith[Polyphone]
+
+  val orchestra = wireAnonymousActor[OrchestraActor]
+
+  orchestra ! Play
+  orchestra ! PlaySoloPolyphone
+  orchestra ! PlaySoloPolyphone
+  orchestra ! PlaySoloPolyphone
+
+  Thread.sleep(100)
+  system.terminate()
+}
+
+
+trait Score
+case object Play
+case object PlaySoloPolyphone
+
+trait Polyphone
+class PolyphoneActor extends Actor {
+  override def receive: Receive = {
+    case Play => println(s"Polyphone ${self.path.name} is playing: uouiiiiiiiiiii")
+  }
+}
+
+trait Violin
+class ViolinActor(score: Score) extends Actor {
+  override def receive: Receive = {
+    case Play => println("Violin is playing: uuuuuuu ...")
+  }
+}
+
+trait Guitar
+class GuitarActor(score: Score)  extends Actor {
+  override def receive: Receive = {
+    case Play => println("Guitar is playing: pa pa pppaaa  ...")
+  }
+}
+
+trait Singer
+class SingerActor(score: Score) extends Actor {
+  override def receive: Receive = {
+    case Play => println(s"${self.path.name} is singing: aaaaa uuuu eeee")
+  }
+}
+
+trait Orchestra
+class OrchestraActor(
+  v: ActorRef @@ Violin,
+  g: ActorRef @@ Guitar,
+  polyphone: ActorRef @@ Polyphone,
+  choir: Set[ActorRef @@ Singer]
+) extends Actor {
+
+  val supportiveChoirScore = new Score {}
+  val supportiveChoir: ActorRef = wireActor[SingerActor]("supportive-choir")
+
+  override def receive: Receive = {
+    case Play =>
+      v ! Play
+      g ! Play
+      g ! Play
+      choir foreach (_ ! Play)
+      supportiveChoir ! Play
+      polyphone ! Play
+    case PlaySoloPolyphone =>
+      polyphone ! Play
+    //...whatever
+  }
+}


### PR DESCRIPTION
Adds `macrosPekko` and `macrosPekkoTests` to be used with Pekko.

See: https://github.com/softwaremill/macwire/issues/301