### PR TITLE
Also detect `@jakarta.inject.Inject` annotations

### DIFF
--- a/macros/src/main/scala-2/com/softwaremill/macwire/internals/ConstructorCrimper.scala
+++ b/macros/src/main/scala-2/com/softwaremill/macwire/internals/ConstructorCrimper.scala
@@ -74,9 +74,12 @@ object ConstructorCrimper {
     lazy val primaryConstructor: Option[Symbol] = publicConstructors.find(_.asMethod.isPrimaryConstructor)
 
     lazy val injectConstructors: Iterable[Symbol] = {
-      val isInjectAnnotation = (a: Annotation) => a.toString == "javax.inject.Inject"
+      val isInjectAnnotation = (a: Annotation) =>
+        a.toString == "javax.inject.Inject" || a.toString == "jakarta.inject.Inject"
       val ctors = publicConstructors.filter(_.annotations.exists(isInjectAnnotation))
-      log.withBlock(s"There are ${ctors.size} constructors annotated with @javax.inject.Inject") {
+      log.withBlock(
+        s"There are ${ctors.size} constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject"
+      ) {
         ctors.foreach(s => log(showConstructor(c)(s)))
       }
       ctors
@@ -86,7 +89,7 @@ object ConstructorCrimper {
       if (injectConstructors.size > 1)
         c.abort(
           c.enclosingPosition,
-          s"Ambiguous constructors annotated with @javax.inject.Inject for type [$targetType]"
+          s"Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [$targetType]"
         )
       else injectConstructors.headOption
 

--- a/macros/src/main/scala-3/com/softwaremill/macwire/internals/ConstructorCrimper.scala
+++ b/macros/src/main/scala-3/com/softwaremill/macwire/internals/ConstructorCrimper.scala
@@ -34,9 +34,12 @@ private[macwire] class ConstructorCrimper[Q <: Quotes, T: Type](using val q: Q)(
   }
 
   lazy val injectConstructors: Iterable[Symbol] = {
-    val isInjectAnnotation = (a: Term) => a.tpe.typeSymbol.fullName == "javax.inject.Inject"
+    val isInjectAnnotation = (a: Term) =>
+      a.tpe.typeSymbol.fullName == "javax.inject.Inject" || a.tpe.typeSymbol.fullName == "jakarta.inject.Inject"
     val ctors = publicConstructors.filter(_.annotations.exists(isInjectAnnotation))
-    log.withBlock(s"There are ${ctors.size} constructors annotated with @javax.inject.Inject") {
+    log.withBlock(
+      s"There are ${ctors.size} constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject"
+    ) {
       ctors.foreach(c => log(showConstructor(c)))
     }
     ctors
@@ -44,7 +47,9 @@ private[macwire] class ConstructorCrimper[Q <: Quotes, T: Type](using val q: Q)(
 
   lazy val injectConstructor: Option[Symbol] =
     if (injectConstructors.size > 1)
-      abort(s"Ambiguous constructors annotated with @javax.inject.Inject for type [${targetType.typeSymbol.name}]")
+      abort(
+        s"Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [${targetType.typeSymbol.name}]"
+      )
     else injectConstructors.headOption
 
   lazy val constructor: Option[Symbol] = log.withBlock(s"Looking for constructor for $targetType") {

--- a/macros/src/main/scala-3/com/softwaremill/macwire/internals/autowire/creator.scala
+++ b/macros/src/main/scala-3/com/softwaremill/macwire/internals/autowire/creator.scala
@@ -87,9 +87,12 @@ object Constructor:
           case c                               => None
 
         val injectConstructors: Iterable[Symbol] =
-          val isInjectAnnotation = (a: Term) => a.tpe.typeSymbol.fullName == "javax.inject.Inject"
+          val isInjectAnnotation = (a: Term) =>
+            a.tpe.typeSymbol.fullName == "javax.inject.Inject" || a.tpe.typeSymbol.fullName == "jakarta.inject.Inject"
           val ctors = publicConstructors.filter(_.annotations.exists(isInjectAnnotation))
-          log.withBlock(s"there are ${ctors.size} constructors annotated with @javax.inject.Inject") {
+          log.withBlock(
+            s"there are ${ctors.size} constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject"
+          ) {
             ctors.foreach(c => log(c.toString))
           }
           ctors
@@ -97,7 +100,7 @@ object Constructor:
         val injectConstructor: Option[Symbol] =
           if injectConstructors.size > 1 then
             reportError(
-              s"multiple constructors annotated with @javax.inject.Inject for type: ${showTypeName(forType)}"
+              s"multiple constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type: ${showTypeName(forType)}"
             )
           else injectConstructors.headOption
 

--- a/macrosAkkaTests/src/test/scala/com/softwaremill/macwire/akkasupport/CompileTests.scala
+++ b/macrosAkkaTests/src/test/scala/com/softwaremill/macwire/akkasupport/CompileTests.scala
@@ -28,13 +28,13 @@ class CompileTests extends CompileTestsSupport {
         "type arguments [NotActor] do not conform to macro method wireActor's type parameter bounds [T <: akka.actor.Actor]"
       ),
       "wireProps-11-toManyInjectAnnotations" -> List(
-        "Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActor]"
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [SomeActor]"
       ),
       "wireAnonymousActor-11-toManyInjectAnnotations" -> List(
-        "Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActor]"
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [SomeActor]"
       ),
       "wireActor-11-toManyInjectAnnotations" -> List(
-        "Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActor]"
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [SomeActor]"
       ),
       "wireProps-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActor]"),
       "wireAnonymousActor-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActor]"),
@@ -54,7 +54,7 @@ class CompileTests extends CompileTestsSupport {
       "wireActorWithProducer-6-injectAnnotationButNoDependencyInScope" -> List("Cannot find a value of type: [C]"),
       "wireActorWithProducer-7-notActorProducer" -> List("wireActorWith does not support the type: [NotProducer]"),
       "wireActorWithProducer-11-toManyInjectAnnotations" -> List(
-        "Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActorProducer]"
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [SomeActorProducer]"
       ),
       "wireActorWithProducer-12-noPublicConstructor" -> List(
         "Cannot find a public constructor for [SomeActorProducer]"
@@ -76,7 +76,7 @@ class CompileTests extends CompileTestsSupport {
         "wireAnonymousActorWith does not support the type: [NotProducer]"
       ),
       "wireAnonymousActorWithProducer-11-toManyInjectAnnotations" -> List(
-        "Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActorProducer]"
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [SomeActorProducer]"
       ),
       "wireAnonymousActorWithProducer-12-noPublicConstructor" -> List(
         "Cannot find a public constructor for [SomeActorProducer]"
@@ -96,7 +96,7 @@ class CompileTests extends CompileTestsSupport {
       "wirePropsWithProducer-6-injectAnnotationButNoDependencyInScope" -> List("Cannot find a value of type: [C]"),
       "wirePropsWithProducer-7-notActorProducer" -> List("wirePropsWith does not support the type: [NotProducer]"),
       "wirePropsWithProducer-11-toManyInjectAnnotations" -> List(
-        "Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActorProducer]"
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [SomeActorProducer]"
       ),
       "wirePropsWithProducer-12-noPublicConstructor" -> List(
         "Cannot find a public constructor for [SomeActorProducer]"

--- a/macrosPekkoTests/src/test/scala/com/softwaremill/macwire/pekkosupport/CompileTests.scala
+++ b/macrosPekkoTests/src/test/scala/com/softwaremill/macwire/pekkosupport/CompileTests.scala
@@ -28,13 +28,13 @@ class CompileTests extends CompileTestsSupport {
         "type arguments [NotActor] do not conform to macro method wireActor's type parameter bounds [T <: org.apache.pekko.actor.Actor]"
       ),
       "wireProps-11-toManyInjectAnnotations" -> List(
-        "Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActor]"
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [SomeActor]"
       ),
       "wireAnonymousActor-11-toManyInjectAnnotations" -> List(
-        "Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActor]"
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [SomeActor]"
       ),
       "wireActor-11-toManyInjectAnnotations" -> List(
-        "Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActor]"
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [SomeActor]"
       ),
       "wireProps-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActor]"),
       "wireAnonymousActor-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActor]"),
@@ -54,7 +54,7 @@ class CompileTests extends CompileTestsSupport {
       "wireActorWithProducer-6-injectAnnotationButNoDependencyInScope" -> List("Cannot find a value of type: [C]"),
       "wireActorWithProducer-7-notActorProducer" -> List("wireActorWith does not support the type: [NotProducer]"),
       "wireActorWithProducer-11-toManyInjectAnnotations" -> List(
-        "Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActorProducer]"
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [SomeActorProducer]"
       ),
       "wireActorWithProducer-12-noPublicConstructor" -> List(
         "Cannot find a public constructor for [SomeActorProducer]"
@@ -76,7 +76,7 @@ class CompileTests extends CompileTestsSupport {
         "wireAnonymousActorWith does not support the type: [NotProducer]"
       ),
       "wireAnonymousActorWithProducer-11-toManyInjectAnnotations" -> List(
-        "Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActorProducer]"
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [SomeActorProducer]"
       ),
       "wireAnonymousActorWithProducer-12-noPublicConstructor" -> List(
         "Cannot find a public constructor for [SomeActorProducer]"
@@ -96,7 +96,7 @@ class CompileTests extends CompileTestsSupport {
       "wirePropsWithProducer-6-injectAnnotationButNoDependencyInScope" -> List("Cannot find a value of type: [C]"),
       "wirePropsWithProducer-7-notActorProducer" -> List("wirePropsWith does not support the type: [NotProducer]"),
       "wirePropsWithProducer-11-toManyInjectAnnotations" -> List(
-        "Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActorProducer]"
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [SomeActorProducer]"
       ),
       "wirePropsWithProducer-12-noPublicConstructor" -> List(
         "Cannot find a public constructor for [SomeActorProducer]"

--- a/tests/src/test/scala-2/com/softwaremill/macwire/CompileTests.scala
+++ b/tests/src/test/scala-2/com/softwaremill/macwire/CompileTests.scala
@@ -31,7 +31,9 @@ class CompileTests extends CompileTestsSupport {
         "Companion object for",
         "Target] has no apply methods constructing target type."
       ),
-      "toManyInjectAnnotations" -> List("Ambiguous constructors annotated with @javax.inject.Inject for type [Target]"),
+      "toManyInjectAnnotations" -> List(
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [Target]"
+      ),
       "nullaryMethodUsedAsCandidate" -> List("Found multiple values of type [A]: [List(Module.foo(), a)]"),
       "wireWithTwoParamsLists" -> List("found   : A => (B => __wrapper$1", "required: ? => __wrapper$1"),
       "wireRecEmptyString" -> List(valueNotFound("String"))

--- a/tests/src/test/scala-3/com/softwaremill/macwire/CompileTests.scala
+++ b/tests/src/test/scala-3/com/softwaremill/macwire/CompileTests.scala
@@ -33,7 +33,9 @@ class CompileTests extends CompileTestsSupport {
         "has no apply methods constructing target type",
         "[Target]"
       ),
-      "toManyInjectAnnotations" -> List("Ambiguous constructors annotated with @javax.inject.Inject for type [Target]"),
+      "toManyInjectAnnotations" -> List(
+        "Ambiguous constructors annotated with @javax.inject.Inject or @jakarta.inject.Inject for type [Target]"
+      ),
       "wireWithTwoParamsLists" -> List("Found:    Main.A => Main.B => Main.Test.C", "Required: Any => Main.Test.C"),
       "wireRecEmptyString" -> List(valueNotFound("String"))
     )


### PR DESCRIPTION
Currently, you are only looking for `javax.inject.Inject` annotations. However, in Play, we are switching to Guice 7, which eventually only supports `jakarta.inject`: https://github.com/google/guice/wiki/Guice700#jee-jakarta-transition

Our samples repo contains a project that is using macwire, but now that we drop `javax.inject`, that project does not work anymore: https://github.com/playframework/play-samples/tree/main/scala/macwire-di (actually this is the PR that makes it fail: https://github.com/playframework/play-samples/pull/799 - which will be updated to just disable that sample for now until this PR here makes it into your next release).

Looking at your code, all it needs is that the `isInjectAnnotation` method also considers the jakarta annotion.

I can confirm, after testing locally, this fix makes the sample's tests work again, on both Scala 2 and 3.

Would be great if you could cut a new release with this fix. Thanks!