### PR TITLE
Correct groupId and (latest) version for sbt-ide-settings

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ val sbtSoftwareMillVersion = "2.0.21"
 addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-common" % sbtSoftwareMillVersion)
 addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-publish" % sbtSoftwareMillVersion)
 
-addSbtPlugin("org.jetbrains" % "sbt-ide-settings" % "1.1.0")
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.2")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.18.2")
 


### PR DESCRIPTION
Does the current groupId work for you? I am not able to resolve it.... I mean, where is it hosted?

Looking at https://github.com/JetBrains/sbt-ide-settings it seems this is the correct plugin location
https://repo1.maven.org/maven2/org/jetbrains/scala/sbt-ide-settings_2.12_1.0/
?

Thanks!